### PR TITLE
Chore: Open source fonts only

### DIFF
--- a/M5Stack-Dial-Test
+++ b/M5Stack-Dial-Test
@@ -104,7 +104,7 @@ image:
     resize: 80x80
 
 font:
-  - file: "fonts/arial.ttf"
+  - file: "gfonts://Lato"
     id: my_font
     size: 40
   


### PR DESCRIPTION
This small change prevents people from having to add a custom font (I know, it's standard arial) to their config and makes the project work from first upload, reducing the friction between users and customizing the project to their needs.